### PR TITLE
Add i18n support and locale toggle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "neuland-website",
@@ -22,6 +21,7 @@
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "12.23.22",
         "graphql": "^16.12.0",
+        "i18n-react": "^0.7.0",
         "lucide-react": "^0.555.0",
         "moment": "^2.30.1",
         "moment-timezone": "0.6.0",
@@ -686,6 +686,8 @@
     "html-whitespace-sensitive-tag-names": ["html-whitespace-sensitive-tag-names@3.0.1", "", {}, "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA=="],
 
     "hyperdyperid": ["hyperdyperid@1.2.0", "", {}, "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="],
+
+    "i18n-react": ["i18n-react@0.7.0", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-rDQs3p5KvRo7/ItFDyMcZQ2BXoVnmOhfahD27Q4loE1U1k7lKW6CsCY9kKbRBdfJSsBGZsaPc7PISg09nhWzJg=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": { "image-size": "bin/image-size.js" } }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,57 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { defaultLocale, isLocale, localeCookieName, locales, type Locale } from '@/lib/i18n/config'
+
+const PUBLIC_FILE = /\.(.*)$/
+
+const getLocaleFromHeader = (request: NextRequest): Locale | null => {
+        const header = request.headers.get('accept-language')
+        if (!header) return null
+        const preferred = header.split(',')[0]?.split('-')[0]?.toLowerCase()
+        if (isLocale(preferred)) return preferred
+        return null
+}
+
+export function middleware(request: NextRequest) {
+        const { pathname, searchParams } = request.nextUrl
+
+        if (
+                pathname.startsWith('/_next') ||
+                pathname.startsWith('/api') ||
+                pathname.startsWith('/assets') ||
+                PUBLIC_FILE.test(pathname)
+        ) {
+                return NextResponse.next()
+        }
+
+        const urlLocale = searchParams.get('lang')
+        const cookieLocale = request.cookies.get(localeCookieName)?.value
+        const pathLocale = locales.find((loc) => pathname === `/${loc}` || pathname.startsWith(`/${loc}/`))
+
+        let locale: Locale = defaultLocale
+
+        if (isLocale(urlLocale)) {
+                locale = urlLocale
+        } else if (isLocale(cookieLocale)) {
+                locale = cookieLocale
+        } else {
+                const headerLocale = getLocaleFromHeader(request)
+                if (headerLocale) locale = headerLocale
+        }
+
+        const response = pathLocale
+                ? NextResponse.rewrite(new URL(pathname.replace(`/${pathLocale}`, '') || '/', request.url))
+                : NextResponse.next()
+
+        const activeLocale = pathLocale && isLocale(pathLocale) ? pathLocale : locale
+        response.cookies.set(localeCookieName, activeLocale, {
+                path: '/',
+                httpOnly: false,
+                maxAge: 60 * 60 * 24 * 365
+        })
+
+        return response
+}
+
+export const config = {
+        matcher: ['/((?!_next|api|.*\\.\w+$).*)']
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "12.23.22",
     "graphql": "^16.12.0",
+    "i18n-react": "^0.7.0",
     "lucide-react": "^0.555.0",
     "moment": "^2.30.1",
     "moment-timezone": "0.6.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import MatrixEffect from '@/components/Background/page-background'
 import TerminalFooter from '@/components/Footer/terminal-footer'
 import TerminalHeader from '@/components/Layout/terminal-header'
 import Providers from '@/components/Provider'
+import { getLocale } from '@/lib/i18n/server'
 
 const overpassMono = Noto_Sans_Mono({
 	variable: '--font-mono',
@@ -84,13 +85,14 @@ const themeScript = `
 `
 
 export default function RootLayout({
-	children
+        children
 }: Readonly<{
-	children: React.ReactNode
+        children: React.ReactNode
 }>) {
-	return (
-		<html lang="de" suppressHydrationWarning>
-			<head>
+        const locale = getLocale()
+        return (
+                <html lang={locale} suppressHydrationWarning>
+                        <head>
 				<meta name="color-scheme" content="dark light" />
 				<meta
 					name="theme-color"
@@ -121,9 +123,9 @@ export default function RootLayout({
 			<body
 				className={`${overpassMono.variable} ${notoSans.variable} font-sans antialiased`}
 			>
-				<Providers>
-					<TerminalHeader />
-					<MatrixEffect />
+                                <Providers locale={locale}>
+                                        <TerminalHeader />
+                                        <MatrixEffect />
 					<div className="container px-4 md:px-12 xl:px-20 mx-auto pt-6 relative z-10">
 						{children}
 						<TerminalFooter />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,26 +7,32 @@ import NextAppShowcase from '@/components/next-app-showcase'
 import ProjectsShowcase from '@/components/Projects/projects-showcase'
 import TerminalMembership from '@/components/terminal-membership'
 import TerminalPartners from '@/components/terminal-partners'
+import { getTranslator } from '@/lib/i18n/server'
 
 export default async function Index() {
-	return (
-		<>
-			<ClientIntro />
-			<EventsSection />
-			<NextAppShowcase />
-			<TerminalSection title="Auszug aus unseren Projekten" headingLevel={2}>
-				<ProjectsShowcase />
-			</TerminalSection>
-			<AboutUsSection />
-			<TerminalSection title="Mitgliedschaft" headingLevel={2} id="membership">
-				<TerminalMembership />
-			</TerminalSection>
-			<TerminalSection title="Partner" headingLevel={2}>
-				<TerminalPartners />
-			</TerminalSection>
-			<TerminalSection title="Neuland Blog" headingLevel={2}>
-				<BlogPreview />
-			</TerminalSection>
-		</>
-	)
+        const t = getTranslator()
+        return (
+                <>
+                        <ClientIntro />
+                        <EventsSection />
+                        <NextAppShowcase />
+                        <TerminalSection title={t.translate('home.projectsTitle') as string} headingLevel={2}>
+                                <ProjectsShowcase />
+                        </TerminalSection>
+                        <AboutUsSection />
+                        <TerminalSection
+                                title={t.translate('home.membershipTitle') as string}
+                                headingLevel={2}
+                                id="membership"
+                        >
+                                <TerminalMembership />
+                        </TerminalSection>
+                        <TerminalSection title={t.translate('home.partnersTitle') as string} headingLevel={2}>
+                                <TerminalPartners />
+                        </TerminalSection>
+                        <TerminalSection title={t.translate('home.blogTitle') as string} headingLevel={2}>
+                                <BlogPreview />
+                        </TerminalSection>
+                </>
+        )
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -4,10 +4,11 @@ import { Code, Filter, Github } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useMemo, useState } from 'react'
 import ProjectCard, {
-	type ProjectDetails
+        type ProjectDetails
 } from '@/components/Projects/project-card'
 import TerminalButton from '@/components/terminal-button'
 import projectsData from '@/data/projects.json'
+import { useTranslations } from '@/contexts/I18nContext'
 
 const uniqueTags = (projectsData as ProjectDetails[]).reduce((acc, project) => {
 	project.tags?.forEach((tag) => {
@@ -17,8 +18,9 @@ const uniqueTags = (projectsData as ProjectDetails[]).reduce((acc, project) => {
 }, new Set<string>())
 
 const ProjectsPage = () => {
-	const router = useRouter()
-	const [activeTag, setActiveTag] = useState<string | null>(null)
+        const router = useRouter()
+        const { translate: t } = useTranslations()
+        const [activeTag, setActiveTag] = useState<string | null>(null)
 
 	const filteredProjects = useMemo(() => {
 		if (!activeTag) return projectsData
@@ -39,60 +41,60 @@ const ProjectsPage = () => {
 				initial={{ opacity: 0, y: -20 }}
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.6 }}
-				className="max-w-6xl mx-auto mb-12"
-			>
-				<div className="flex items-center gap-3 mb-6">
-					<h1 className="text-3xl md:text-4xl font-bold  font-mono">
-						Unsere Projekte
-					</h1>
-				</div>
+                                className="max-w-6xl mx-auto mb-12"
+                        >
+                                <div className="flex items-center gap-3 mb-6">
+                                        <h1 className="text-3xl md:text-4xl font-bold  font-mono">
+                                                {t('projects.title')}
+                                        </h1>
+                                </div>
 
-				<motion.p
-					initial={{ opacity: 0 }}
-					animate={{ opacity: 1 }}
-					transition={{ duration: 0.6, delay: 0.2 }}
-					className="text-lg text-terminal-text/80 font-mono max-w-3xl"
-				>
-					Entdecke unsere Sammlung kreativer, technischer und
-					gemeinschaftsgetriebener Projekte. Von Webanwendungen bis hin zu
-					Cybersecurity-Initiativen.
-				</motion.p>
+                                <motion.p
+                                        initial={{ opacity: 0 }}
+                                        animate={{ opacity: 1 }}
+                                        transition={{ duration: 0.6, delay: 0.2 }}
+                                        className="text-lg text-terminal-text/80 font-mono max-w-3xl"
+                                >
+                                        {t('projects.description')}
+                                </motion.p>
 
-				<motion.div
-					initial={{ opacity: 0, y: 10 }}
-					animate={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.6, delay: 0.4 }}
-					className="flex items-center gap-2 mt-6 text-sm text-terminal-text/60 font-mono"
-				>
-					<Code size={16} />
-					<span>
-						{filteredProjects.length} Projekt
-						{filteredProjects.length !== 1 ? 'e' : ''} gefunden
-					</span>
-				</motion.div>
-			</motion.div>
+                                <motion.div
+                                        initial={{ opacity: 0, y: 10 }}
+                                        animate={{ opacity: 1, y: 0 }}
+                                        transition={{ duration: 0.6, delay: 0.4 }}
+                                        className="flex items-center gap-2 mt-6 text-sm text-terminal-text/60 font-mono"
+                                >
+                                        <Code size={16} />
+                                        <span>
+                                                {t('projects.count', {
+                                                        count: filteredProjects.length,
+                                                        suffix: filteredProjects.length !== 1 ? 'e' : ''
+                                                })}
+                                        </span>
+                                </motion.div>
+                        </motion.div>
 
 			{/* Filter Section */}
 			<div className="max-w-6xl mx-auto mb-8">
-				<div className="flex items-center gap-3 mb-4">
-					<Filter size={20} className="text-terminal-cyan" />
-					<span className="text-terminal-text/80 font-mono">
-						Filter nach Technologie:
-					</span>
-				</div>
+                                <div className="flex items-center gap-3 mb-4">
+                                        <Filter size={20} className="text-terminal-cyan" />
+                                        <span className="text-terminal-text/80 font-mono">
+                                                {t('projects.filterLabel')}
+                                        </span>
+                                </div>
 
 				<div className="flex flex-wrap gap-3">
 					<button
 						type="button"
-						className={`px-4 py-2  border transition-all duration-200 ${
-							!activeTag
-								? 'border-terminal-cyan bg-terminal-cyan/80 text-terminal-onAccent'
-								: 'border-terminal-text/30 text-terminal-text/70 hover:border-terminal-cyan hover:text-terminal-cyan'
-						}`}
-						onClick={() => setActiveTag(null)}
-					>
-						Alle Projekte
-					</button>
+                                                className={`px-4 py-2  border transition-all duration-200 ${
+                                                        !activeTag
+                                                                ? 'border-terminal-cyan bg-terminal-cyan/80 text-terminal-onAccent'
+                                                                : 'border-terminal-text/30 text-terminal-text/70 hover:border-terminal-cyan hover:text-terminal-cyan'
+                                                }`}
+                                                onClick={() => setActiveTag(null)}
+                                        >
+                                                {t('projects.all')}
+                                        </button>
 					{[...uniqueTags].map((tag) => (
 						<button
 							type="button"
@@ -134,17 +136,17 @@ const ProjectsPage = () => {
 
 				{/* Empty State */}
 				{filteredProjects.length === 0 && (
-					<motion.div
-						initial={{ opacity: 0 }}
-						animate={{ opacity: 1 }}
-						className="text-center py-12"
-					>
-						<Code size={48} className="text-terminal-text/40 mx-auto mb-4" />
-						<p className="text-terminal-text/60 font-mono">
-							Keine Projekte gefunden für diesen Filter.
-						</p>
-					</motion.div>
-				)}
+                                        <motion.div
+                                                initial={{ opacity: 0 }}
+                                                animate={{ opacity: 1 }}
+                                                className="text-center py-12"
+                                        >
+                                                <Code size={48} className="text-terminal-text/40 mx-auto mb-4" />
+                                                <p className="text-terminal-text/60 font-mono">
+                                                        {t('projects.empty')}
+                                                </p>
+                                        </motion.div>
+                                )}
 			</div>
 
 			{/* Footer Section */}
@@ -155,24 +157,24 @@ const ProjectsPage = () => {
 				className="max-w-6xl mx-auto mt-16 pt-8 border-t border-terminal-text/20"
 			>
 				<div className="text-center">
-					<div className="flex items-center justify-center gap-2 mb-4">
-						<span className="text-terminal-text/80 font-mono">
-							Sieh dir unsere Projekte auf GitHub an!
-						</span>
-					</div>
-					<TerminalButton
-						href="https://github.com/neuland-ingolstadt"
-						target="_blank"
-						rel="noreferrer noopener"
-					>
-						<Github
-							size={16}
-							className="mr-2 group-hover:rotate-8 transition-transform duration-300"
-						/>
-						Mehr erfahren
-					</TerminalButton>
-				</div>
-			</motion.div>
+                                        <div className="flex items-center justify-center gap-2 mb-4">
+                                                <span className="text-terminal-text/80 font-mono">
+                                                        {t('projects.github')}
+                                                </span>
+                                        </div>
+                                        <TerminalButton
+                                                href="https://github.com/neuland-ingolstadt"
+                                                target="_blank"
+                                                rel="noreferrer noopener"
+                                        >
+                                                <Github
+                                                        size={16}
+                                                        className="mr-2 group-hover:rotate-8 transition-transform duration-300"
+                                                />
+                                                {t('projects.more')}
+                                        </TerminalButton>
+                                </div>
+                        </motion.div>
 		</div>
 	)
 }

--- a/src/components/AboutUs/about-us-section.tsx
+++ b/src/components/AboutUs/about-us-section.tsx
@@ -3,28 +3,30 @@ import { motion } from 'framer-motion'
 import { Lightbulb, Rocket, Users } from 'lucide-react'
 import type React from 'react'
 import TerminalSection from '@/components/Layout/terminal-section'
+import { useTranslations } from '@/contexts/I18nContext'
 
 const AboutUsSection: React.FC = () => {
-	const features = [
-		{
-			icon: <Rocket className="h-6 w-6 text-terminal-cyan" />,
-			title: 'Projekte & Wettbewerbe',
-			desc: 'Wir entwickeln innovative Projekte, nehmen an Wettbewerben teil und fördern Kreativität.'
-		},
-		{
-			icon: <Lightbulb className="h-6 w-6 text-terminal-cyan" />,
-			title: 'Veranstaltungen & Wissen',
-			desc: 'Wir organisieren Events rund um Informatik und Technik – offen für alle Fakultäten und Studiengänge.'
-		},
-		{
-			icon: <Users className="h-6 w-6 text-terminal-cyan" />,
-			title: 'Community & Networking',
-			desc: 'Lerne neue Leute kennen, vernetze dich und werde Teil einer aktiven, hilfsbereiten Studierenden-Community.'
-		}
-	]
+        const { translate: t } = useTranslations()
+        const features = [
+                {
+                        icon: <Rocket className="h-6 w-6 text-terminal-cyan" />,
+                        title: t('about.featureProjects'),
+                        desc: t('about.featureProjectsDesc')
+                },
+                {
+                        icon: <Lightbulb className="h-6 w-6 text-terminal-cyan" />,
+                        title: t('about.featureKnowledge'),
+                        desc: t('about.featureKnowledgeDesc')
+                },
+                {
+                        icon: <Users className="h-6 w-6 text-terminal-cyan" />,
+                        title: t('about.featureCommunity'),
+                        desc: t('about.featureCommunityDesc')
+                }
+        ]
 
-	return (
-		<TerminalSection title="Über uns" headingLevel={2}>
+        return (
+                <TerminalSection title={t('about.title')} headingLevel={2}>
 			{/* Unified container */}
 			<motion.div
 				initial={{ opacity: 0, y: 20 }}
@@ -55,15 +57,14 @@ const AboutUsSection: React.FC = () => {
 				<div className="absolute inset-0 bg-gradient-to-b from-terminal-cyan/3 via-transparent to-transparent pointer-events-none" />
 
 				{/* Main intro section */}
-				<div className="p-6 border-b border-terminal-window-border relative z-10">
-					<h3 className="text-xl font-semibold text-terminal-text mb-3">
-						Gemeinschaft & Plattform
-					</h3>
-					<p className="text-terminal-text/90 leading-relaxed m-0">
-						Wir bieten Studierenden eine Plattform zum Austausch, zur
-						Projektarbeit und zur Wissensvermittlung .
-					</p>
-				</div>
+                                <div className="p-6 border-b border-terminal-window-border relative z-10">
+                                        <h3 className="text-xl font-semibold text-terminal-text mb-3">
+                                                {t('about.introTitle')}
+                                        </h3>
+                                        <p className="text-terminal-text/90 leading-relaxed m-0">
+                                                {t('about.introBody')}
+                                        </p>
+                                </div>
 
 				{/* Feature cards section */}
 				<div className="relative z-10">

--- a/src/components/Events/calendar-modal.tsx
+++ b/src/components/Events/calendar-modal.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Check, Copy, X } from 'lucide-react'
 import type React from 'react'
 import { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from '@/contexts/I18nContext'
 
 interface CalendarModalProps {
 	isOpen: boolean
@@ -12,10 +13,11 @@ interface CalendarModalProps {
 
 const CalendarModal: React.FC<CalendarModalProps> = ({
 	isOpen,
-	onClose,
-	icalUrl
+        onClose,
+        icalUrl
 }) => {
-	const [copied, setCopied] = useState(false)
+        const { translate: t } = useTranslations()
+        const [copied, setCopied] = useState(false)
 
 	const copyToClipboard = useCallback(() => {
 		navigator.clipboard.writeText(icalUrl).then(() => {
@@ -84,8 +86,8 @@ const CalendarModal: React.FC<CalendarModalProps> = ({
 							}}
 							role="dialog"
 							aria-modal="true"
-							aria-labelledby="calendar-modal-title"
-						>
+                                                        aria-labelledby="calendar-modal-title"
+                                                >
 							{/* Corner accent brackets */}
 							<div className="absolute top-0 left-0 w-12 h-12">
 								<div className="absolute top-0 left-0 w-6 h-px bg-terminal-cyan/30" />
@@ -109,41 +111,40 @@ const CalendarModal: React.FC<CalendarModalProps> = ({
 
 							{/* Header */}
 							<div className="relative z-10 bg-terminal-card border-b border-terminal-window-border px-4 py-3 flex items-center">
-								<div
-									id="calendar-modal-title"
-									className="flex-1 text-center text-sm font-semibold text-terminal-text"
-								>
-									ical-subscribe.sh --import-events
-								</div>
-								<button
-									onClick={onClose}
-									className="ml-4 p-1 text-terminal-text/70 hover:text-terminal-text transition-colors duration-200"
-									aria-label="Schließen"
-									type="button"
-								>
-									<X size={18} />
+                                                                <div
+                                                                        id="calendar-modal-title"
+                                                                        className="flex-1 text-center text-sm font-semibold text-terminal-text"
+                                                                >
+                                                                        {t('events.icalTitle')}
+                                                                </div>
+                                                                <button
+                                                                        onClick={onClose}
+                                                                        className="ml-4 p-1 text-terminal-text/70 hover:text-terminal-text transition-colors duration-200"
+                                                                        aria-label={t('events.close')}
+                                                                        type="button"
+                                                                >
+                                                                        <X size={18} />
 								</button>
 							</div>
 
-							{/* Content */}
-							<div className="p-6 relative z-10">
-								<p className="mb-6 leading-relaxed">
-									Du kannst alle Neuland Events in deinen Kalender als iCal
-									Abonnement hinzufügen.
-								</p>
+                                                        {/* Content */}
+                                                        <div className="p-6 relative z-10">
+                                                                <p className="mb-6 leading-relaxed">
+                                                                        {t('events.icalBody')}
+                                                                </p>
 
 								<div className="bg-terminal-card p-3 border border-terminal-window-border mb-6 font-mono text-xs relative group">
 									<div className="flex items-center justify-between">
 										<span className="break-all pr-2 w-[calc(100%-30px)] text-terminal-text/70">
 											{icalUrl}
 										</span>
-										<button
-											onClick={copyToClipboard}
-											className="shrink-0 ml-1 text-terminal-text/70 hover:text-terminal-cyan transition-colors duration-200"
-											aria-label="URL kopieren"
-											title="URL kopieren"
-											type="button"
-										>
+                                                                                <button
+                                                                                        onClick={copyToClipboard}
+                                                                                        className="shrink-0 ml-1 text-terminal-text/70 hover:text-terminal-cyan transition-colors duration-200"
+                                                                                        aria-label={t('events.share')}
+                                                                                        title={t('events.share')}
+                                                                                        type="button"
+                                                                                >
 											{copied ? (
 												<Check size={16} className="text-terminal-cyan" />
 											) : (
@@ -151,19 +152,20 @@ const CalendarModal: React.FC<CalendarModalProps> = ({
 											)}
 										</button>
 									</div>
-								</div>
+                                                                </div>
 
-								<h3 className="text-lg text-terminal-cyan mb-3 font-semibold">
-									So gehts:
-								</h3>
-								<ul className="list-disc list-inside space-y-2 mb-0 text-terminal-text/70">
-									<li>Kopiere die URL</li>
-									<li>Öffne deine Kalender App</li>
-									<li>Erstelle ein neues iCal Abonnement</li>
-									<li>Die Events werden automatisch aktualisiert</li>
-								</ul>
-							</div>
-						</div>
+                                                                <h3 className="text-lg text-terminal-cyan mb-3 font-semibold">
+                                                                        {t('events.details')}
+                                                                </h3>
+                                                                <ul className="list-disc list-inside space-y-2 mb-0 text-terminal-text/70">
+                                                                        {t('events.steps')
+                                                                                .split('|')
+                                                                                .map((step, index) => (
+                                                                                        <li key={index}>{step}</li>
+                                                                                ))}
+                                                                </ul>
+                                                        </div>
+                                                </div>
 					</motion.div>
 				</>
 			)}

--- a/src/components/Events/terminal-events.tsx
+++ b/src/components/Events/terminal-events.tsx
@@ -8,6 +8,7 @@ import TerminalButton from '@/components/terminal-button'
 import TerminalList from '@/components/terminal-list'
 import { cn } from '@/lib/utils'
 import type { fetchEvents } from '@/services/events'
+import { useTranslations } from '@/contexts/I18nContext'
 import CalendarModal from './calendar-modal'
 
 interface TerminalEventsProps {
@@ -16,13 +17,14 @@ interface TerminalEventsProps {
 }
 
 const TerminalEvents: React.FC<TerminalEventsProps> = ({
-	initialData,
-	error: serverError
+        initialData,
+        error: serverError
 }) => {
-	const eventsData = initialData || {
-		semester: `SS ${new Date().getFullYear()}`,
-		events: []
-	}
+        const { translate: t } = useTranslations()
+        const eventsData = initialData || {
+                semester: `SS ${new Date().getFullYear()}`,
+                events: []
+        }
 	const error = serverError
 
 	const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(
@@ -60,12 +62,14 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 		setIsCalModalOpen(false)
 	}, [])
 
-	return (
-		<TerminalSection
-			title="Unsere Veranstaltungen"
-			subtitle={`Events im ${eventsData?.semester || `SS ${new Date().getFullYear()}`}`}
-			headingLevel={2}
-		>
+        return (
+                <TerminalSection
+                        title={t('events.title')}
+                        subtitle={t('events.semester', {
+                                semester: eventsData?.semester || `SS ${new Date().getFullYear()}`
+                        })}
+                        headingLevel={2}
+                >
 			<div className="max-w-5xl mx-auto justify-start mt-10 mb-8 relative overflow-visible min-h-[200px] font-mono">
 				<TerminalWindow
 					title={`eventsData.sh --semester '${eventsData?.semester || `SS ${new Date().getFullYear()}`}'`}
@@ -79,41 +83,38 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 					>
 						<TerminalList>
 							{error ? (
-								<div className="p-4 text-terminal-lightGreen">
-									<p className="text-md mb-2">
-										Oh nein! Beim Abrufen der Events ist etwas schiefgelaufen.
-									</p>
-									<p className="text-sm text-terminal-lightGreen/60">
-										{typeof error === 'object' &&
+                                                                <div className="p-4 text-terminal-lightGreen">
+                                                                        <p className="text-md mb-2">
+                                                                                {t('events.errorHeading')}
+                                                                        </p>
+                                                                        <p className="text-sm text-terminal-lightGreen/60">
+                                                                                {typeof error === 'object' &&
 										error !== null &&
 										'message' in error
 											? (error as { message: string }).message
-											: typeof error === 'string'
-												? error
-												: 'Unbekannter Fehler'}
-									</p>
-									<p className="text-sm mt-4 text-terminal-text/70">
-										Unsere Serverwartungsmannschaft macht gerade wohl
-										Kaffeepause.
-										<br />
-										Bitte versuche es später noch einmal!
-									</p>
-								</div>
-							) : !eventsData?.events || eventsData.events.length === 0 ? (
-								<div className="p-4 text-terminal-text font-bold">
-									<p className="text-md mb-3">
-										Danke für eure Teilnahme an den über 20 Events in diesem
-										Semester! 🎉
-									</p>
-									<p className="text-sm mb-3 text-terminal-text/80">
-										Wir arbeiten bereits an spannenden neuen Events für das
-										kommende Semester.
-										<br />
-										<span className="text-terminal-highlight">$</span>{' '}
-										./prepare_ctf.sh --season WS25/26 --hype-level=MAXIMUM
-									</p>
-								</div>
-							) : (
+                                                                                        : typeof error === 'string'
+                                                                                                ? error
+                                                                                                : 'Unknown error'}
+                                                                        </p>
+                                                                        <p className="text-sm mt-4 text-terminal-text/70">
+                                                                                {t('events.errorDetails')}
+                                                                                <br />
+                                                                                {t('events.errorRetry')}
+                                                                        </p>
+                                                                </div>
+                                                        ) : !eventsData?.events || eventsData.events.length === 0 ? (
+                                                                <div className="p-4 text-terminal-text font-bold">
+                                                                        <p className="text-md mb-3">
+                                                                                {t('events.emptyHeading')}
+                                                                        </p>
+                                                                        <p className="text-sm mb-3 text-terminal-text/80">
+                                                                                {t('events.emptyBody')}
+                                                                                <br />
+                                                                                <span className="text-terminal-highlight">$</span>{' '}
+                                                                                {t('events.emptyCommand')}
+                                                                        </p>
+                                                                </div>
+                                                        ) : (
 								<div
 									ref={containerRef}
 									className="min-h-[250px] h-auto relative"
@@ -169,16 +170,16 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 															))}
 													</div>
 
-													<strong
-														className={cn('text-terminal-lightGreen text-lg', {
-															hidden:
-																!eventsData.events[selectedEventIndex]
-																	.description
-														})}
-													>
-														Details
-													</strong>
-												</div>
+                                                                                                        <strong
+                                                                                                                className={cn('text-terminal-lightGreen text-lg', {
+                                                                                                                        hidden:
+                                                                                                                                !eventsData.events[selectedEventIndex]
+                                                                                                                                        .description
+                                                                                                                })}
+                                                                                                        >
+                                                                                                                {t('events.details')}
+                                                                                                        </strong>
+                                                                                                </div>
 
 												<div
 													className="overflow-y-auto overflow-x-hidden pr-4 max-w-full flex-1"
@@ -203,17 +204,17 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 												<div className="flex-none pt-3 pb-4">
 													<button
 														onClick={resetSelectedEvent}
-														className="text-terminal-text transition-colors px-2 py-1 text-sm inline-flex items-center font-bold group bg-terminal-card border border-terminal-window-border hover:bg-terminal-window-border/30"
-														type="button"
-													>
-														<LucideArrowBigLeft
-															size={16}
-															className="mr-1 group-hover:text-terminal-highlight transition-colors"
-														/>
-														Alle Events
-													</button>
-												</div>
-											</div>
+                                                                                                className="text-terminal-text transition-colors px-2 py-1 text-sm inline-flex items-center font-bold group bg-terminal-card border border-terminal-window-border hover:bg-terminal-window-border/30"
+                                                                                                type="button"
+                                                                                        >
+                                                                                                <LucideArrowBigLeft
+                                                                                                        size={16}
+                                                                                                        className="mr-1 group-hover:text-terminal-highlight transition-colors"
+                                                                                                />
+                                                                                                {t('events.title')}
+                                                                                        </button>
+                                                                                </div>
+                                                                        </div>
 										)}
 									</div>
 
@@ -268,17 +269,17 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 							)}
 						</TerminalList>
 					</div>
-				</TerminalWindow>
+                                </TerminalWindow>
 
-				<div className="flex sm:justify-end -mt-4 ">
-					<TerminalButton onClick={openCalModal}>
-						<CalendarIcon
-							size={16}
-							className="mr-2 group-hover:rotate-8 transition-transform duration-300"
-						/>
-						Events abonnieren
-					</TerminalButton>
-				</div>
+                                <div className="flex sm:justify-end -mt-4 ">
+                                        <TerminalButton onClick={openCalModal}>
+                                                <CalendarIcon
+                                                        size={16}
+                                                        className="mr-2 group-hover:rotate-8 transition-transform duration-300"
+                                                />
+                                                {t('events.calendarCta')}
+                                        </TerminalButton>
+                                </div>
 
 				<CalendarModal
 					isOpen={isCalModalOpen}

--- a/src/components/Layout/terminal-header.tsx
+++ b/src/components/Layout/terminal-header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Menu } from 'lucide-react'
+import { Globe2, Menu } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import type React from 'react'
@@ -14,34 +14,20 @@ import {
 	SidebarHeader,
 	SidebarMenu,
 	SidebarMenuButton,
-	SidebarMenuItem,
-	SidebarProvider,
-	useSidebar
+        SidebarMenuItem,
+        SidebarProvider,
+        useSidebar
 } from '@/components/ui/sidebar'
 import { useBackground } from '@/contexts/BackgroundContext'
+import { useTranslations } from '@/contexts/I18nContext'
 
 import NeulandLogo from './neuland-logo'
 import ThemeToggle, { ThemeToggleMobile } from './theme-toggle'
 
-const navLinks = [
-	{
-		name: 'Mitglied werden',
-		href: '/#membership',
-		external: false
-	},
-	{ name: 'Projekte', href: '/projects', external: false },
-	{ name: 'Blog', href: '/blog', external: false },
-	{
-		name: 'Login',
-		href: 'https://sso.informatik.sexy',
-		external: true
-	}
-]
-
 interface NavLinkProps {
-	link: {
-		name: string
-		href: string
+        link: {
+                name: string
+                href: string
 		external?: boolean
 	}
 	className?: string
@@ -75,14 +61,32 @@ const DesktopNavLink: React.FC<NavLinkProps> = ({ link, className }) => {
 }
 
 const MobileSidebar: React.FC = () => {
-	const pathname = usePathname()
-	const { isMobile, setOpenMobile } = useSidebar()
+        const pathname = usePathname()
+        const { isMobile, setOpenMobile } = useSidebar()
+        const { translate: t, locale, setLocale } = useTranslations()
 
-	const handleNavigation = () => {
-		if (isMobile) {
-			setOpenMobile(false)
-		}
-	}
+        const handleNavigation = () => {
+                if (isMobile) {
+                        setOpenMobile(false)
+                }
+        }
+
+        const navLinks = [
+                {
+                        name: t('nav.membership'),
+                        href: '/#membership',
+                        external: false
+                },
+                { name: t('nav.projects'), href: '/projects', external: false },
+                { name: t('nav.blog'), href: '/blog', external: false },
+                {
+                        name: t('nav.login'),
+                        href: 'https://sso.informatik.sexy',
+                        external: true
+                }
+        ]
+
+        const toggleLocale = () => setLocale(locale === 'de' ? 'en' : 'de')
 
 	return (
 		<Sidebar variant="sidebar" side="bottom">
@@ -129,18 +133,31 @@ const MobileSidebar: React.FC = () => {
 						</SidebarMenu>
 					</SidebarGroupContent>
 				</SidebarGroup>
-			</SidebarContent>
+                        </SidebarContent>
 
-			<SidebarFooter className="border-t border-terminal-window-border/70 bg-terminal-bg/95 px-4 py-3">
-				<div className="flex items-center justify-between gap-4 text-xs text-terminal-text/60">
-					<span className="uppercase tracking-[0.18em] text-[0.65rem] text-terminal-text/70">
-						Theme
-					</span>
-					<ThemeToggleMobile />
-				</div>
-			</SidebarFooter>
-		</Sidebar>
-	)
+                        <SidebarFooter className="border-t border-terminal-window-border/70 bg-terminal-bg/95 px-4 py-3">
+                                <div className="flex items-center justify-between gap-4 text-xs text-terminal-text/60">
+                                        <span className="uppercase tracking-[0.18em] text-[0.65rem] text-terminal-text/70">
+                                                Theme
+                                        </span>
+                                        <ThemeToggleMobile />
+                                </div>
+                                <div className="mt-3 flex items-center justify-between gap-4 text-xs text-terminal-text/60">
+                                        <span className="uppercase tracking-[0.18em] text-[0.65rem] text-terminal-text/70">
+                                                {t('nav.language')}
+                                        </span>
+                                        <button
+                                                type="button"
+                                                onClick={toggleLocale}
+                                                className="inline-flex items-center gap-1 rounded-md border border-terminal-window-border/70 px-2 py-1 text-terminal-text hover:text-terminal-cyan hover:border-terminal-cyan transition-colors"
+                                        >
+                                                <Globe2 className="h-4 w-4" />
+                                                <span className="font-semibold">{locale === 'de' ? 'DE' : 'EN'}</span>
+                                        </button>
+                                </div>
+                        </SidebarFooter>
+                </Sidebar>
+        )
 }
 
 const MobileSidebarTrigger: React.FC = () => {
@@ -172,14 +189,30 @@ const MobileSidebarTrigger: React.FC = () => {
 }
 
 const TerminalHeader: React.FC = () => {
-	const headerRef = useRef<HTMLElement>(null)
-	const navigate = useRouter()
-	const isJune = new Date().getMonth() === 5
-	const { triggerCrossesRotation } = useBackground()
+        const headerRef = useRef<HTMLElement>(null)
+        const navigate = useRouter()
+        const isJune = new Date().getMonth() === 5
+        const { triggerCrossesRotation } = useBackground()
+        const { translate: t, locale, setLocale } = useTranslations()
 
-	// Dynamically set --navbar-height on the document root for robust layout
-	useEffect(() => {
-		const setNavbarHeight = () => {
+        const navLinks = [
+                {
+                        name: t('nav.membership'),
+                        href: '/#membership',
+                        external: false
+                },
+                { name: t('nav.projects'), href: '/projects', external: false },
+                { name: t('nav.blog'), href: '/blog', external: false },
+                {
+                        name: t('nav.login'),
+                        href: 'https://sso.informatik.sexy',
+                        external: true
+                }
+        ]
+
+        // Dynamically set --navbar-height on the document root for robust layout
+        useEffect(() => {
+                const setNavbarHeight = () => {
 			if (headerRef.current) {
 				const height = headerRef.current.getBoundingClientRect().height
 				document.documentElement.style.setProperty(
@@ -193,14 +226,16 @@ const TerminalHeader: React.FC = () => {
 		return () => window.removeEventListener('resize', setNavbarHeight)
 	}, [])
 
-	const handleHomeClick = (e: React.MouseEvent) => {
-		e.preventDefault()
-		navigate.replace('/')
-	}
+        const handleHomeClick = (e: React.MouseEvent) => {
+                e.preventDefault()
+                navigate.replace('/')
+        }
 
-	return (
-		<SidebarProvider>
-			<header
+        const toggleLocale = () => setLocale(locale === 'de' ? 'en' : 'de')
+
+        return (
+                <SidebarProvider>
+                        <header
 				ref={headerRef}
 				className="terminal-nav fixed top-0 left-0 right-0 z-50 border-b border-terminal-window-border/80 bg-terminal-bg/80 py-3 backdrop-blur-md"
 			>
@@ -229,16 +264,24 @@ const TerminalHeader: React.FC = () => {
 					</div>
 
 					{/* Desktop Navigation */}
-					<nav className="hidden items-center gap-6 md:flex">
-						{navLinks.map((link) => (
-							<DesktopNavLink
-								key={link.name}
-								link={link}
-								className="tracking-wider text-terminal-text transition-colors hover:text-terminal-cyan"
-							/>
-						))}
-						<ThemeToggle />
-					</nav>
+                                        <nav className="hidden items-center gap-6 md:flex">
+                                                {navLinks.map((link) => (
+                                                        <DesktopNavLink
+                                                                key={link.name}
+                                                                link={link}
+                                                                className="tracking-wider text-terminal-text transition-colors hover:text-terminal-cyan"
+                                                        />
+                                                ))}
+                                                <button
+                                                        type="button"
+                                                        onClick={toggleLocale}
+                                                        className="flex items-center gap-2 rounded-md border border-terminal-window-border/70 px-3 py-1.5 text-sm font-semibold text-terminal-text transition-colors hover:border-terminal-cyan hover:text-terminal-cyan"
+                                                >
+                                                        <Globe2 className="h-4 w-4" />
+                                                        <span>{locale === 'de' ? t('nav.german') : t('nav.english')}</span>
+                                                </button>
+                                                <ThemeToggle />
+                                        </nav>
 
 					{/* Mobile Menu Button (Sidebar trigger) */}
 					<div className="flex items-center md:hidden">

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -3,14 +3,16 @@
 import { AptabaseProvider } from '@aptabase/react'
 // Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
 import {
-	type DehydratedState,
-	HydrationBoundary,
-	isServer,
-	QueryClient,
-	QueryClientProvider
+        type DehydratedState,
+        HydrationBoundary,
+        isServer,
+        QueryClient,
+        QueryClientProvider
 } from '@tanstack/react-query'
 import { useState } from 'react'
 import { BackgroundProvider } from '@/contexts/BackgroundContext'
+import { I18nProvider } from '@/contexts/I18nContext'
+import type { Locale } from '@/lib/i18n/config'
 import RouteTracker from './Layout/route-tracker'
 
 function makeQueryClient() {
@@ -44,11 +46,13 @@ function getQueryClient() {
 }
 
 export default function Providers({
-	children,
-	dehydratedState
+        children,
+        dehydratedState,
+        locale
 }: {
-	children: React.ReactNode
-	dehydratedState?: DehydratedState
+        children: React.ReactNode
+        dehydratedState?: DehydratedState
+        locale?: Locale
 }) {
 	// In React 18, we need to use useState here to create a new query client
 	// on the server for each request, to avoid sharing state between users.
@@ -56,21 +60,23 @@ export default function Providers({
 	// prevent it from being shared between requests.
 	const [queryClient] = useState(() => getQueryClient())
 	const APTABASE_KEY = process.env.NEXT_PUBLIC_APTABASE_KEY ?? ''
-	return (
-		<BackgroundProvider>
-			<AptabaseProvider
-				appKey={APTABASE_KEY}
-				options={{
-					host: 'https://analytics.neuland.app'
-				}}
-			>
-				<QueryClientProvider client={queryClient}>
-					<HydrationBoundary state={dehydratedState}>
-						{children}
-						<RouteTracker />
-					</HydrationBoundary>
-				</QueryClientProvider>
-			</AptabaseProvider>
-		</BackgroundProvider>
-	)
+        return (
+                <BackgroundProvider>
+                        <AptabaseProvider
+                                appKey={APTABASE_KEY}
+                                options={{
+                                        host: 'https://analytics.neuland.app'
+                                }}
+                        >
+                                <QueryClientProvider client={queryClient}>
+                                        <I18nProvider initialLocale={locale}>
+                                                <HydrationBoundary state={dehydratedState}>
+                                                        {children}
+                                                        <RouteTracker />
+                                                </HydrationBoundary>
+                                        </I18nProvider>
+                                </QueryClientProvider>
+                        </AptabaseProvider>
+                </BackgroundProvider>
+        )
 }

--- a/src/components/client-intro.tsx
+++ b/src/components/client-intro.tsx
@@ -1,14 +1,16 @@
 import TypewriterText from '@/components/typewriter-text'
+import { useTranslations } from '@/contexts/I18nContext'
 
 export default function ClientIntro() {
-	return (
-		<div className={'pt-20'}>
-			<TypewriterText
-				text="Der studentische Verein für alle informatikbegeisterten Studierenden der TH Ingolstadt."
-				className="text-xl mb-12 font-mono font-semibold text-terminal-text/90"
-				delay={25}
-				preventLayoutJumps={true}
-			/>
+        const { translate: t } = useTranslations()
+        return (
+                <div className={'pt-20'}>
+                        <TypewriterText
+                                text={t('home.intro')}
+                                className="text-xl mb-12 font-mono font-semibold text-terminal-text/90"
+                                delay={25}
+                                preventLayoutJumps={true}
+                        />
 		</div>
 	)
 }

--- a/src/components/next-app-showcase.tsx
+++ b/src/components/next-app-showcase.tsx
@@ -1,9 +1,9 @@
 'use client'
 import { AnimatePresence, motion, type Variants } from 'framer-motion'
 import {
-	ArrowUpRight,
-	Bell,
-	BookOpen,
+        ArrowUpRight,
+        Bell,
+        BookOpen,
 	Calendar,
 	ForkKnife,
 	GithubIcon,
@@ -12,17 +12,19 @@ import {
 	MapPin,
 	Shield,
 	TrendingUp,
-	Users,
-	Zap
+        Users,
+        Zap
 } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import FeatureItem from './feature-item'
 import TerminalButton from './terminal-button'
+import { useTranslations } from '@/contexts/I18nContext'
 
 const NextAppShowcase = () => {
-	const phoneRef = useRef<HTMLDivElement>(null)
-	const [activeIndex, setActiveIndex] = useState(0)
-	const screenshots = [
+        const { translate: t } = useTranslations()
+        const phoneRef = useRef<HTMLDivElement>(null)
+        const [activeIndex, setActiveIndex] = useState(0)
+        const screenshots = [
 		'/assets/neuland-next/next_1.webp',
 		'/assets/neuland-next/next_2.webp',
 		'/assets/neuland-next/next_4.webp',
@@ -45,10 +47,10 @@ const NextAppShowcase = () => {
 		})
 	}, [screenshots])
 
-	const imageVariants = {
-		initial: {
-			opacity: 0
-		},
+        const imageVariants = {
+                initial: {
+                        opacity: 0
+                },
 		animate: {
 			opacity: 1,
 			transition: {
@@ -63,61 +65,60 @@ const NextAppShowcase = () => {
 				ease: 'easeInOut'
 			}
 		}
-	}
+        }
 
-	const features = [
-		{
-			icon: <Calendar className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Stundenplan & Prüfungen',
-			description: 'Dein persönlicher Stundenplan und alle Prüfungen'
-		},
-		{
-			icon: <Calendar className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Kalender & Events',
-			description: 'Alle wichtigen Semesterdaten und Campus-Events'
-		},
-		{
-			icon: <Users className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Profil',
-			description: 'Prüfe deine Noten oder dein Druckguthaben'
-		},
-		{
-			icon: <ForkKnife className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Mensa',
-			description: 'Alle Speisepläne mit Preisen, Allergenen und Nährwerten'
-		},
-		{
-			icon: <MapPin className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Campus-Karte',
-			description:
-				'Finde freie Räume, erkunde Gebäude oder nutze smarte Vorschläge'
-		},
-		{
-			icon: <BookOpen className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Bibliothek',
-			description: 'Nutze deinen virtuellen Bibliotheks Code zum Ausleihen'
-		},
-		{
-			icon: <Globe className="h-5 w-5 text-terminal-cyan" />,
-			title: 'Quick Links',
-			description: 'Alle wichtigen Uni-Plattformen wie Moodle oder Primuss'
-		},
-		{
-			icon: <Bell className="h-5 w-5 text-terminal-cyan" />,
-			title: 'THI News',
-			description: 'Bleibe informiert mit den neuesten Nachrichten der THI'
-		}
-	]
+        const features = [
+                {
+                        icon: <Calendar className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.schedule'),
+                        description: t('next.features.scheduleDesc')
+                },
+                {
+                        icon: <Calendar className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.calendar'),
+                        description: t('next.features.calendarDesc')
+                },
+                {
+                        icon: <Users className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.profile'),
+                        description: t('next.features.profileDesc')
+                },
+                {
+                        icon: <ForkKnife className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.canteen'),
+                        description: t('next.features.canteenDesc')
+                },
+                {
+                        icon: <MapPin className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.map'),
+                        description: t('next.features.mapDesc')
+                },
+                {
+                        icon: <BookOpen className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.library'),
+                        description: t('next.features.libraryDesc')
+                },
+                {
+                        icon: <Globe className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.links'),
+                        description: t('next.features.linksDesc')
+                },
+                {
+                        icon: <Bell className="h-5 w-5 text-terminal-cyan" />,
+                        title: t('next.features.news'),
+                        description: t('next.features.newsDesc')
+                }
+        ]
 
-	const highlights = [
-		{ icon: <Shield className="h-4 w-4" />, text: 'Maximaler Datenschutz' },
+        const highlights = [
+                { icon: <Shield className="h-4 w-4" />, text: t('next.highlights.privacy') },
 
-		{ icon: <Zap className="h-4 w-4" />, text: 'Blitzschnelle Performance' },
-		{ icon: <GithubIcon className="h-4 w-4" />, text: '100% Open Source' },
-		{ icon: <TrendingUp className="h-4 w-4" />, text: 'Regelmäßige Updates' },
-		{ icon: <Globe className="h-4 w-4" />, text: 'Offline-fähig' },
-		{ icon: <Laptop className="h-4 w-4" />, text: 'Auch als Web App' }
-	]
+                { icon: <Zap className="h-4 w-4" />, text: t('next.highlights.performance') },
+                { icon: <GithubIcon className="h-4 w-4" />, text: t('next.highlights.oss') },
+                { icon: <TrendingUp className="h-4 w-4" />, text: t('next.highlights.updates') },
+                { icon: <Globe className="h-4 w-4" />, text: t('next.highlights.offline') },
+                { icon: <Laptop className="h-4 w-4" />, text: t('next.highlights.web') }
+        ]
 
 	return (
 		<div className="w-full pt-12 pb-16 relative">
@@ -127,21 +128,19 @@ const NextAppShowcase = () => {
 					initial={{ opacity: 0, y: 20 }}
 					whileInView={{ opacity: 1, y: 0 }}
 					transition={{ duration: 0.6 }}
-					viewport={{ once: true }}
-					className="text-center mb-16"
-				>
-					<h2 className="text-4xl mb-2 font-bold  bg-clip-text ">
-						Neuland Next
-					</h2>
-					<b className="text-xl/loose b-6 font-black ">
-						Deine App für die TH Ingolstadt
-					</b>
-					<p className="text-lg text-terminal-text/80 max-w-3xl mx-auto">
-						Deine moderne Campus-App von Neuland Ingolstadt. Entwickelt mit
-						Liebe zum Detail, vollständig Open Source und auf allen Geräten
-						verfügbar.
-					</p>
-				</motion.div>
+                                        viewport={{ once: true }}
+                                        className="text-center mb-16"
+                                >
+                                        <h2 className="text-4xl mb-2 font-bold  bg-clip-text ">
+                                                {t('next.heading')}
+                                        </h2>
+                                        <b className="text-xl/loose b-6 font-black ">
+                                                {t('next.subheading')}
+                                        </b>
+                                        <p className="text-lg text-terminal-text/80 max-w-3xl mx-auto">
+                                                {t('next.description')}
+                                        </p>
+                                </motion.div>
 
 				{/* Main Content Grid */}
 				<div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-start mb-20">
@@ -218,22 +217,20 @@ const NextAppShowcase = () => {
 							{/* Subtle background gradient */}
 							<div className="absolute inset-0 bg-gradient-to-br from-terminal-cyan/2 via-transparent to-terminal-cyan/1 pointer-events-none" />
 
-							<div className="relative z-10">
-								<h3 className="text-2xl mb-3 font-semibold text-terminal-text">
-									Unser Flaggschiff-Projekt
-								</h3>
+                                                        <div className="relative z-10">
+                                                                <h3 className="text-2xl mb-3 font-semibold text-terminal-text">
+                                                                        {t('next.flagshipTitle')}
+                                                                </h3>
 
-								<p className="mb-8 text-base leading-relaxed text-terminal-text/70">
-									Neuland Next ist mehr als nur eine App – es ist dein digitaler
-									Begleiter durch den Studienalltag an der THI. Alle wichtigen
-									Funktionen für deinen Campus-Alltag in einer App.
-								</p>
+                                                                <p className="mb-8 text-base leading-relaxed text-terminal-text/70">
+                                                                        {t('next.flagshipBody')}
+                                                                </p>
 
 								{/* Highlights */}
-								<div className="mb-8 pb-8 border-b border-terminal-window-border">
-									<h4 className="text-sm font-semibold mb-4 text-terminal-cyan uppercase tracking-wider">
-										Warum Neuland Next
-									</h4>
+                                                                <div className="mb-8 pb-8 border-b border-terminal-window-border">
+                                                                        <h4 className="text-sm font-semibold mb-4 text-terminal-cyan uppercase tracking-wider">
+                                                                                {t('next.why')}
+                                                                        </h4>
 									<div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
 										{highlights.map((highlight, idx) => (
 											<motion.div
@@ -256,10 +253,10 @@ const NextAppShowcase = () => {
 								</div>
 
 								{/* Download Section */}
-								<div className="mb-6">
-									<div className="text-xs font-semibold mb-4 text-terminal-cyan/80 uppercase tracking-wider">
-										Jetzt herunterladen
-									</div>
+                                                                <div className="mb-6">
+                                                                        <div className="text-xs font-semibold mb-4 text-terminal-cyan/80 uppercase tracking-wider">
+                                                                                {t('next.download')}
+                                                                        </div>
 									<div className="flex flex-col sm:flex-row gap-3 mb-6">
 										<a
 											href="https://apps.apple.com/app/neuland-next/id1617096811"
@@ -294,16 +291,16 @@ const NextAppShowcase = () => {
 									href="https://neuland.app"
 									dark
 									target="_blank"
-									rel="noreferrer noopener"
-								>
-									<ArrowUpRight
-										size={16}
-										className="mr-2 group-hover:rotate-8 transition-transform duration-300"
-									/>
-									Mehr erfahren
-								</TerminalButton>
-							</div>
-						</motion.div>
+                                                                        rel="noreferrer noopener"
+                                                                >
+                                                                        <ArrowUpRight
+                                                                                size={16}
+                                                                                className="mr-2 group-hover:rotate-8 transition-transform duration-300"
+                                                                        />
+                                                                        {t('next.cta')}
+                                                                </TerminalButton>
+                                                        </div>
+                                                </motion.div>
 					</div>
 				</div>
 
@@ -311,13 +308,13 @@ const NextAppShowcase = () => {
 				<motion.div
 					initial={{ opacity: 0, y: 30 }}
 					whileInView={{ opacity: 1, y: 0 }}
-					transition={{ duration: 0.8 }}
-					viewport={{ once: true }}
-					className="mb-16 hidden lg:block"
-				>
-					<h3 className="text-2xl font-bold text-center mb-12">
-						Die Features auf einen Blick
-					</h3>
+                                        transition={{ duration: 0.8 }}
+                                        viewport={{ once: true }}
+                                        className="mb-16 hidden lg:block"
+                                >
+                                        <h3 className="text-2xl font-bold text-center mb-12">
+                                                {t('next.featuresHeading')}
+                                        </h3>
 					<div className="relative bg-terminal-window border border-terminal-window-border overflow-hidden">
 						{/* Outer accent corners */}
 						<div className="absolute top-0 left-0 w-16 h-16 border-t-2 border-l-2 border-terminal-cyan/30" />

--- a/src/components/terminal-membership.tsx
+++ b/src/components/terminal-membership.tsx
@@ -2,11 +2,13 @@
 import { motion } from 'framer-motion'
 import { Mail, UserPlus, Zap } from 'lucide-react'
 import TerminalButton from './terminal-button'
+import { useTranslations } from '@/contexts/I18nContext'
 
 const TerminalMembership = () => {
-	return (
-		<div className="my-10 w-full">
-			<div className="relative bg-terminal-window border border-terminal-window-border overflow-hidden">
+        const { translate: t } = useTranslations()
+        return (
+                <div className="my-10 w-full">
+                        <div className="relative bg-terminal-window border border-terminal-window-border overflow-hidden">
 				{/* Creative accent - top border highlight */}
 				<div className="absolute top-0 left-0 right-0 h-px bg-terminal-cyan/40" />
 
@@ -18,101 +20,93 @@ const TerminalMembership = () => {
 					<motion.div
 						initial={{ opacity: 0, x: -20 }}
 						whileInView={{ opacity: 1, x: 0 }}
-						transition={{ duration: 0.5 }}
-						viewport={{ once: true }}
-						className="lg:w-2/5 p-6 border-b lg:border-b-0 lg:border-r border-terminal-window-border"
-					>
-						<div className="text-terminal-text/60 mb-4 font-mono text-sm">
-							$ cat membership-fees.txt
-						</div>
-						<div className="flex flex-col gap-5">
-							<div className="flex items-center justify-between">
-								<span className="text-terminal-highlight font-medium">
-									Studierende:
-								</span>
-								<span className="text-terminal-text ml-2 font-bold font-mono text-lg">
-									5€ / Jahr
-								</span>
-							</div>
-							<div className="flex items-center justify-between">
-								<span className="text-terminal-highlight font-medium">
-									Externe:
-								</span>
-								<span className="text-terminal-text ml-2 font-bold font-mono text-lg">
-									20€ / Jahr
-								</span>
-							</div>
-						</div>
-					</motion.div>
+                                                transition={{ duration: 0.5 }}
+                                                viewport={{ once: true }}
+                                                className="lg:w-2/5 p-6 border-b lg:border-b-0 lg:border-r border-terminal-window-border"
+                                        >
+                                                <div className="text-terminal-text/60 mb-4 font-mono text-sm">{t('membership.feesTitle')}</div>
+                                                <div className="flex flex-col gap-5">
+                                                        <div className="flex items-center justify-between">
+                                                                <span className="text-terminal-highlight font-medium">{t('membership.students')}</span>
+                                                                <span className="text-terminal-text ml-2 font-bold font-mono text-lg">
+                                                                        {t('membership.studentsPrice')}
+                                                                </span>
+                                                        </div>
+                                                        <div className="flex items-center justify-between">
+                                                                <span className="text-terminal-highlight font-medium">{t('membership.external')}</span>
+                                                                <span className="text-terminal-text ml-2 font-bold font-mono text-lg">
+                                                                        {t('membership.externalPrice')}
+                                                                </span>
+                                                        </div>
+                                                </div>
+                                        </motion.div>
 
 					{/* Benefits Section */}
 					<motion.div
 						initial={{ opacity: 0, x: 20 }}
 						whileInView={{ opacity: 1, x: 0 }}
-						transition={{ duration: 0.5, delay: 0.1 }}
-						viewport={{ once: true }}
-						className="md:w-3/5 p-6 space-y-5"
-					>
-						<h4 className="text-xl font-semibold flex items-center">
-							<Zap size={18} className="text-terminal-cyan mr-2" />
-							Deine Vorteile:
-						</h4>
+                                                transition={{ duration: 0.5, delay: 0.1 }}
+                                                viewport={{ once: true }}
+                                                className="md:w-3/5 p-6 space-y-5"
+                                        >
+                                                <h4 className="text-xl font-semibold flex items-center">
+                                                        <Zap size={18} className="text-terminal-cyan mr-2" />
+                                                        {t('membership.benefitsTitle')}
+                                                </h4>
 
 						<div className="space-y-3">
 							<div className="flex items-start group">
-								<span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
-									•
-								</span>
-								<p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
-									Teil eines aktiven studentischen Vereins mit regelmäßigen
-									Treffen und Austausch
-								</p>
-							</div>
-							<div className="flex items-start group">
-								<span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
-									•
-								</span>
-								<p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
-									Gemeinsame Arbeit an Open-Source Projekten
-								</p>
-							</div>
-							<div className="flex items-start group">
-								<span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
-									•
-								</span>
-								<p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
-									Exklusive Workshops, Hackathons und soziale Events mit
-									Gleichgesinnten
-								</p>
-							</div>
-						</div>
+                                                                <span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
+                                                                        •
+                                                                </span>
+                                                                <p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
+                                                                        {t('membership.benefitCommunity')}
+                                                                </p>
+                                                        </div>
+                                                        <div className="flex items-start group">
+                                                                <span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
+                                                                        •
+                                                                </span>
+                                                                <p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
+                                                                        {t('membership.benefitProjects')}
+                                                                </p>
+                                                        </div>
+                                                        <div className="flex items-start group">
+                                                                <span className="text-terminal-cyan mr-3 text-xl group-hover:scale-110 transition-transform duration-300 shrink-0 mt-0.5">
+                                                                        •
+                                                                </span>
+                                                                <p className="text-terminal-text/70 group-hover:text-terminal-text transition-colors duration-300 mb-0">
+                                                                        {t('membership.benefitEvents')}
+                                                                </p>
+                                                        </div>
+                                                </div>
 
 						<div className="pt-2 flex flex-wrap gap-3">
 							<TerminalButton
-								href="https://join.neuland-ingolstadt.de/"
-								dark
-								target="_blank"
-								rel="noreferrer noopener"
-							>
+                                                                href="https://join.neuland-ingolstadt.de/"
+                                                                dark
+                                                                target="_blank"
+                                                                rel="noreferrer noopener"
+                                                        >
 								<UserPlus
-									size={16}
-									className="mr-2 group-hover:rotate-8 transition-transform duration-300"
-								/>
-								Mitglied werden
-							</TerminalButton>
-							<TerminalButton
-								href="mailto:info@neuland-ingolstadt.de?subject=Frage%20zur%20Mitgliedschaft"
+                                                                        size={16}
+                                                                        className="mr-2 group-hover:rotate-8 transition-transform duration-300"
+                                                                />
+                                                                {t('membership.join')}
+                                                        </TerminalButton>
+                                                        <TerminalButton
+                                                                href="mailto:info@neuland-ingolstadt.de?subject=Frage%20zur%20Mitgliedschaft"
 								dark
 							>
 								<Mail
-									size={16}
-									className="mr-2 group-hover:rotate-8 transition-transform duration-300"
-								/>
-								E-Mail schreiben
-							</TerminalButton>
-						</div>
-					</motion.div>
-				</div>
+                                                                        size={16}
+                                                                        className="mr-2 group-hover:rotate-8 transition-transform duration-300"
+                                                                />
+                                                                {t('membership.email')}
+                                                        </TerminalButton>
+                                                </div>
+                                        </motion.div>
+                                </div>
 			</div>
 		</div>
 	)

--- a/src/contexts/I18nContext.tsx
+++ b/src/contexts/I18nContext.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { MDText } from 'i18n-react'
+import { usePathname, useRouter } from 'next/navigation'
+import {
+        createContext,
+        useCallback,
+        useContext,
+        useEffect,
+        useMemo,
+        useState
+} from 'react'
+import { dictionaries } from '@/lib/i18n/dictionaries'
+import { defaultLocale, isLocale, localeCookieName, type Locale } from '@/lib/i18n/config'
+
+interface I18nContextValue {
+        locale: Locale
+        translate: (key: string, params?: Record<string, unknown>) => string
+        setLocale: (locale: Locale) => void
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null)
+
+const getInitialLocale = (initialLocale?: Locale): Locale => {
+        if (initialLocale && isLocale(initialLocale)) return initialLocale
+        if (typeof window !== 'undefined') {
+                                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                const saved = document.cookie
+                        .split('; ')
+                        .find((row) => row.startsWith(`${localeCookieName}=`))
+                        ?.split('=')[1]
+                if (isLocale(saved)) return saved
+        }
+        return defaultLocale
+}
+
+export const I18nProvider = ({
+        children,
+        initialLocale
+}: {
+        children: React.ReactNode
+        initialLocale?: Locale
+}) => {
+        const pathname = usePathname()
+        const router = useRouter()
+        const [locale, setLocaleState] = useState<Locale>(() => getInitialLocale(initialLocale))
+
+        const translator = useMemo(() => new MDText(dictionaries[locale], { MDFlavor: 0 }), [locale])
+
+        const translate = useCallback(
+                (key: string, params?: Record<string, unknown>) => {
+                        const result = translator.translate(key, params)
+                        if (typeof result === 'string') return result
+                        if (Array.isArray(result)) return result.join(' ')
+                        return String(result ?? key)
+                },
+                [translator]
+        )
+
+        useEffect(() => {
+                document.documentElement.lang = locale
+                const expires = new Date()
+                expires.setFullYear(expires.getFullYear() + 1)
+                document.cookie = `${localeCookieName}=${locale}; path=/; expires=${expires.toUTCString()}`
+        }, [locale])
+
+        const setLocale = useCallback(
+                (nextLocale: Locale) => {
+                        setLocaleState(nextLocale)
+                        if (!pathname) return
+
+                        const withoutLocalePrefix = pathname.startsWith('/en')
+                                ? pathname.replace('/en', '') || '/'
+                                : pathname
+                        if (nextLocale === 'en') {
+                                if (!pathname.startsWith('/en')) {
+                                        router.replace(`/en${withoutLocalePrefix === '/' ? '' : withoutLocalePrefix}`)
+                                }
+                        } else if (pathname.startsWith('/en')) {
+                                router.replace(withoutLocalePrefix || '/')
+                        }
+                        router.refresh()
+                },
+                [pathname, router]
+        )
+
+        return (
+                <I18nContext.Provider value={{ locale, translate, setLocale }}>
+                        {children}
+                </I18nContext.Provider>
+        )
+}
+
+export const useTranslations = () => {
+        const context = useContext(I18nContext)
+        if (!context) {
+                throw new Error('useTranslations must be used within I18nProvider')
+        }
+        return context
+}

--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -1,0 +1,10 @@
+export const locales = ['de', 'en'] as const
+
+export type Locale = (typeof locales)[number]
+
+export const defaultLocale: Locale = 'de'
+
+export const localeCookieName = 'NEXT_LOCALE'
+
+export const isLocale = (value: string | undefined | null): value is Locale =>
+        Boolean(value && locales.includes(value as Locale))

--- a/src/lib/i18n/dictionaries.ts
+++ b/src/lib/i18n/dictionaries.ts
@@ -1,0 +1,8 @@
+import de from '@/locales/de.json'
+import en from '@/locales/en.json'
+import type { Locale } from './config'
+
+export const dictionaries: Record<Locale, Record<string, unknown>> = {
+        de,
+        en
+}

--- a/src/lib/i18n/server.ts
+++ b/src/lib/i18n/server.ts
@@ -1,0 +1,30 @@
+import { cookies, headers } from 'next/headers'
+import { MDText } from 'i18n-react'
+import { defaultLocale, isLocale, localeCookieName, type Locale } from './config'
+import { dictionaries } from './dictionaries'
+
+const parseAcceptLanguage = (headerValue: string | null): Locale | null => {
+        if (!headerValue) return null
+        const preferred = headerValue.split(',')[0]?.split('-')[0]?.toLowerCase()
+        if (preferred && isLocale(preferred)) {
+                return preferred
+        }
+        return null
+}
+
+export const getLocale = (): Locale => {
+        const cookieStore = cookies()
+        const cookieLocale = cookieStore.get(localeCookieName)?.value
+        if (isLocale(cookieLocale)) return cookieLocale
+
+        const headerLocale = parseAcceptLanguage(headers().get('accept-language'))
+        if (headerLocale) return headerLocale
+
+        return defaultLocale
+}
+
+export const getTranslator = (locale?: Locale) => {
+        const activeLocale = locale && isLocale(locale) ? locale : getLocale()
+        const dictionary = dictionaries[activeLocale]
+        return new MDText(dictionary, { MDFlavor: 0 })
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,0 +1,108 @@
+{
+  "nav": {
+    "membership": "Mitglied werden",
+    "projects": "Projekte",
+    "blog": "Blog",
+    "login": "Login",
+    "language": "Sprache",
+    "german": "Deutsch",
+    "english": "Englisch"
+  },
+  "home": {
+    "intro": "Der studentische Verein für alle informatikbegeisterten Studierenden der TH Ingolstadt.",
+    "projectsTitle": "Auszug aus unseren Projekten",
+    "membershipTitle": "Mitgliedschaft",
+    "partnersTitle": "Partner",
+    "blogTitle": "Neuland Blog"
+  },
+  "events": {
+    "title": "Unsere Veranstaltungen",
+    "semester": "Events im {{semester}}",
+    "errorHeading": "Oh nein! Beim Abrufen der Events ist etwas schiefgelaufen.",
+    "errorDetails": "Unsere Serverwartungsmannschaft macht gerade wohl Kaffeepause.",
+    "errorRetry": "Bitte versuche es später noch einmal!",
+    "emptyHeading": "Danke für eure Teilnahme an den über 20 Events in diesem Semester! 🎉",
+    "emptyBody": "Wir arbeiten bereits an spannenden neuen Events für das kommende Semester.",
+    "emptyCommand": "./prepare_ctf.sh --season WS25/26 --hype-level=MAXIMUM",
+    "details": "Details",
+    "calendarCta": "Kalender abonnieren",
+    "downloadIcs": ".ics herunterladen",
+    "close": "Schließen",
+    "icalDescription": "Füge alle kommenden Events zu deinem Kalender hinzu",
+    "share": "Kalender teilen",
+    "icalTitle": "ical-subscribe.sh --import-events",
+    "icalBody": "Du kannst alle Neuland Events in deinen Kalender als iCal Abonnement hinzufügen.",
+    "steps": "Kopiere die URL|Öffne deine Kalender App|Erstelle ein neues iCal Abonnement|Die Events werden automatisch aktualisiert"
+  },
+  "about": {
+    "title": "Über uns",
+    "introTitle": "Gemeinschaft & Plattform",
+    "introBody": "Wir bieten Studierenden eine Plattform zum Austausch, zur Projektarbeit und zur Wissensvermittlung .",
+    "featureProjects": "Projekte & Wettbewerbe",
+    "featureProjectsDesc": "Wir entwickeln innovative Projekte, nehmen an Wettbewerben teil und fördern Kreativität.",
+    "featureKnowledge": "Veranstaltungen & Wissen",
+    "featureKnowledgeDesc": "Wir organisieren Events rund um Informatik und Technik – offen für alle Fakultäten und Studiengänge.",
+    "featureCommunity": "Community & Networking",
+    "featureCommunityDesc": "Lerne neue Leute kennen, vernetze dich und werde Teil einer aktiven, hilfsbereiten Studierenden-Community."
+  },
+  "next": {
+    "heading": "Neuland Next",
+    "subheading": "Deine App für die TH Ingolstadt",
+    "description": "Deine moderne Campus-App von Neuland Ingolstadt. Entwickelt mit Liebe zum Detail, vollständig Open Source und auf allen Geräten verfügbar.",
+    "cta": "Zur App",
+    "flagshipTitle": "Unser Flaggschiff-Projekt",
+    "flagshipBody": "Neuland Next ist mehr als nur eine App – es ist dein digitaler Begleiter durch den Studienalltag an der THI. Alle wichtigen Funktionen für deinen Campus-Alltag in einer App.",
+    "why": "Warum Neuland Next",
+    "download": "Jetzt herunterladen",
+    "featuresHeading": "Die Features auf einen Blick",
+    "features": {
+      "schedule": "Stundenplan & Prüfungen",
+      "scheduleDesc": "Dein persönlicher Stundenplan und alle Prüfungen",
+      "calendar": "Kalender & Events",
+      "calendarDesc": "Alle wichtigen Semesterdaten und Campus-Events",
+      "profile": "Profil",
+      "profileDesc": "Prüfe deine Noten oder dein Druckguthaben",
+      "canteen": "Mensa",
+      "canteenDesc": "Alle Speisepläne mit Preisen, Allergenen und Nährwerten",
+      "map": "Campus-Karte",
+      "mapDesc": "Finde freie Räume, erkunde Gebäude oder nutze smarte Vorschläge",
+      "library": "Bibliothek",
+      "libraryDesc": "Nutze deinen virtuellen Bibliotheks Code zum Ausleihen",
+      "links": "Quick Links",
+      "linksDesc": "Alle wichtigen Uni-Plattformen wie Moodle oder Primuss",
+      "news": "THI News",
+      "newsDesc": "Bleibe informiert mit den neuesten Nachrichten der THI"
+    },
+    "highlights": {
+      "privacy": "Maximaler Datenschutz",
+      "performance": "Blitzschnelle Performance",
+      "oss": "100% Open Source",
+      "updates": "Regelmäßige Updates",
+      "offline": "Offline-fähig",
+      "web": "Auch als Web App"
+    }
+  },
+  "membership": {
+    "feesTitle": "$ cat membership-fees.txt",
+    "students": "Studierende:",
+    "studentsPrice": "5€ / Jahr",
+    "external": "Externe:",
+    "externalPrice": "20€ / Jahr",
+    "benefitsTitle": "Deine Vorteile:",
+    "benefitCommunity": "Teil eines aktiven studentischen Vereins mit regelmäßigen Treffen und Austausch",
+    "benefitProjects": "Gemeinsame Arbeit an Open-Source Projekten",
+    "benefitEvents": "Exklusive Workshops, Hackathons und soziale Events mit Gleichgesinnten",
+    "join": "Mitglied werden",
+    "email": "E-Mail schreiben"
+  },
+  "projects": {
+    "title": "Unsere Projekte",
+    "description": "Entdecke unsere Sammlung kreativer, technischer und gemeinschaftsgetriebener Projekte. Von Webanwendungen bis hin zu Cybersecurity-Initiativen.",
+    "count": "{{count}} Projekt{{suffix}} gefunden",
+    "filterLabel": "Filter nach Technologie:",
+    "all": "Alle Projekte",
+    "empty": "Keine Projekte gefunden für diesen Filter.",
+    "github": "Sieh dir unsere Projekte auf GitHub an!",
+    "more": "Mehr erfahren"
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,108 @@
+{
+  "nav": {
+    "membership": "Become a member",
+    "projects": "Projects",
+    "blog": "Blog",
+    "login": "Login",
+    "language": "Language",
+    "german": "German",
+    "english": "English"
+  },
+  "home": {
+    "intro": "The student-run club for everyone at TH Ingolstadt who loves computer science.",
+    "projectsTitle": "A selection of our projects",
+    "membershipTitle": "Membership",
+    "partnersTitle": "Partners",
+    "blogTitle": "Neuland Blog"
+  },
+  "events": {
+    "title": "Our events",
+    "semester": "Events in {{semester}}",
+    "errorHeading": "Oh no! Something went wrong while fetching the events.",
+    "errorDetails": "Our server maintenance crew is probably on a coffee break right now.",
+    "errorRetry": "Please try again later!",
+    "emptyHeading": "Thanks for joining more than 20 events this semester! 🎉",
+    "emptyBody": "We are already working on exciting new events for the upcoming term.",
+    "emptyCommand": "./prepare_ctf.sh --season WS25/26 --hype-level=MAXIMUM",
+    "details": "Details",
+    "calendarCta": "Subscribe to calendar",
+    "downloadIcs": "Download .ics",
+    "close": "Close",
+    "icalDescription": "Add all upcoming events to your calendar",
+    "share": "Share calendar",
+    "icalTitle": "ical-subscribe.sh --import-events",
+    "icalBody": "You can add every Neuland event to your calendar via an iCal subscription.",
+    "steps": "Copy the URL|Open your calendar app|Create a new iCal subscription|Events will stay in sync automatically"
+  },
+  "about": {
+    "title": "About us",
+    "introTitle": "Community & platform",
+    "introBody": "We provide students with a place to connect, work on projects and share knowledge.",
+    "featureProjects": "Projects & competitions",
+    "featureProjectsDesc": "We build innovative projects, join competitions and encourage creativity.",
+    "featureKnowledge": "Events & knowledge",
+    "featureKnowledgeDesc": "We host events about computer science and tech – open to every faculty and degree program.",
+    "featureCommunity": "Community & networking",
+    "featureCommunityDesc": "Meet new people, make connections and become part of a helpful student community."
+  },
+  "next": {
+    "heading": "Neuland Next",
+    "subheading": "Your app for TH Ingolstadt",
+    "description": "Your modern campus app from Neuland Ingolstadt. Crafted with attention to detail, fully open source and available on every device.",
+    "cta": "Open the app",
+    "flagshipTitle": "Our flagship project",
+    "flagshipBody": "Neuland Next is more than just an app – it is your digital companion throughout student life at THI. All essential campus features in one place.",
+    "why": "Why Neuland Next",
+    "download": "Download now",
+    "featuresHeading": "Features at a glance",
+    "features": {
+      "schedule": "Schedule & exams",
+      "scheduleDesc": "Your personal timetable and all exams",
+      "calendar": "Calendar & events",
+      "calendarDesc": "All important semester dates and campus events",
+      "profile": "Profile",
+      "profileDesc": "Check your grades or printing balance",
+      "canteen": "Cafeteria",
+      "canteenDesc": "All menus with prices, allergens and nutrition facts",
+      "map": "Campus map",
+      "mapDesc": "Find free rooms, explore buildings or use smart suggestions",
+      "library": "Library",
+      "libraryDesc": "Use your virtual library code to borrow items",
+      "links": "Quick links",
+      "linksDesc": "All essential university platforms like Moodle or Primuss",
+      "news": "THI news",
+      "newsDesc": "Stay up to date with the latest news from THI"
+    },
+    "highlights": {
+      "privacy": "Maximum privacy",
+      "performance": "Lightning-fast performance",
+      "oss": "100% open source",
+      "updates": "Frequent updates",
+      "offline": "Works offline",
+      "web": "Also available as a web app"
+    }
+  },
+  "membership": {
+    "feesTitle": "$ cat membership-fees.txt",
+    "students": "Students:",
+    "studentsPrice": "5€ / year",
+    "external": "External:",
+    "externalPrice": "20€ / year",
+    "benefitsTitle": "Your benefits:",
+    "benefitCommunity": "Part of an active student club with regular meetups and exchange",
+    "benefitProjects": "Work together on open-source projects",
+    "benefitEvents": "Exclusive workshops, hackathons and social events with like-minded people",
+    "join": "Join now",
+    "email": "Send email"
+  },
+  "projects": {
+    "title": "Our projects",
+    "description": "Discover our collection of creative, technical and community-driven projects. From web apps to cybersecurity initiatives.",
+    "count": "{{count}} project{{suffix}} found",
+    "filterLabel": "Filter by technology:",
+    "all": "All projects",
+    "empty": "No projects found for this filter.",
+    "github": "Check out our projects on GitHub!",
+    "more": "Learn more"
+  }
+}


### PR DESCRIPTION
## Summary
- add i18n-react dictionaries and locale-aware provider with middleware-based detection
- translate key navigation, home, events, projects, and membership content with a navbar locale toggle
- integrate language selection into layout and content components while keeping blog paths untouched

## Testing
- bun run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d2b5130883309c57169ff5b743fd)