### PR TITLE
fix: remove button with link to offline ctf website

### DIFF
--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -26,10 +26,6 @@
 			{
 				"label": "CTFtime",
 				"url": "https://ctftime.org/team/150968"
-			},
-			{
-				"label": "Neuland CTF",
-				"url": "https://ctf.neuland-ingolstadt.de"
 			}
 		],
 		"tags": ["Cybersecurity"],


### PR DESCRIPTION
Removed a broken link button pointing to the offline Neuland CTF page.