### PR TITLE
feat: i18n events homepage

### DIFF
--- a/src/components/Events/terminal-events.tsx
+++ b/src/components/Events/terminal-events.tsx
@@ -294,7 +294,9 @@ const TerminalEvents: React.FC<TerminalEventsProps> = ({
 											>
 												<div className="flex flex-wrap items-center gap-2">
 													<strong className="text-terminal-lightGreen text-[1.05rem] wrap-break-word">
-														{event.title}
+														{locale.startsWith('de')
+															? event.titleDe
+															: event.titleEn}
 														{event.location && (
 															<span className="text-terminal-text/60 ml-2">
 																@{event.location}


### PR DESCRIPTION
This pull request updates the `TerminalEvents` component to support displaying event titles and descriptions in either German or English, depending on the user's locale. The component now uses the `useLocale` hook to determine the current language and conditionally renders the appropriate localized fields for each event.

Localization improvements:

* Added the `useLocale` hook from `next-intl` to determine the user's current locale. [[1]](diffhunk://#diff-0689f62b87cccc3790b9cc947366b317a855f018255062adcee3092c2157139cL3-R3) [[2]](diffhunk://#diff-0689f62b87cccc3790b9cc947366b317a855f018255062adcee3092c2157139cR51)
* Updated event title and description rendering logic to display German (`titleDe`, `descriptionDe`) or English (`titleEn`, `descriptionEn`) fields based on whether the locale starts with 'de'. [[1]](diffhunk://#diff-0689f62b87cccc3790b9cc947366b317a855f018255062adcee3092c2157139cL169-R172) [[2]](diffhunk://#diff-0689f62b87cccc3790b9cc947366b317a855f018255062adcee3092c2157139cL234-R241) [[3]](diffhunk://#diff-0689f62b87cccc3790b9cc947366b317a855f018255062adcee3092c2157139cL291-R299)

Related issues:

Closes #25