### PR TITLE
chore: update student membership fee to 10€ per year

### DIFF
--- a/src/components/TerminalMembership.tsx
+++ b/src/components/TerminalMembership.tsx
@@ -31,7 +31,7 @@ const TerminalMembership = () => {
 									Studierende:
 								</span>
 								<span className="text-terminal-text ml-2 font-bold font-mono text-lg">
-									5€ / Jahr
+									10€ / Jahr
 								</span>
 							</div>
 							<div className="flex items-center justify-between">

--- a/src/components/terminal-membership.tsx
+++ b/src/components/terminal-membership.tsx
@@ -34,7 +34,7 @@ const TerminalMembership = () => {
 									{t('pricing.students')}:
 								</span>
 								<span className="text-terminal-text ml-2 font-bold font-mono text-lg">
-									5€ / {t('pricing.year')}
+									10€ / {t('pricing.year')}
 								</span>
 							</div>
 							<div className="flex items-center justify-between">


### PR DESCRIPTION
This pull request updates the displayed annual membership fee for students in two components to reflect a new price.

Pricing update:

* Increased the student membership fee from 5€ to 10€ per year in both `TerminalMembership.tsx` and `terminal-membership.tsx` components. [[1]](diffhunk://#diff-bf423a5f1a5b96be5856a2c550730d9a1cece62ac9bfff2a85ecf7b23af9172fL34-R34) [[2]](diffhunk://#diff-f75af29476356398e8ad5eda8a8332ea2f2628869b5fa6a3e60f8caab702078cL37-R37)